### PR TITLE
Fix flickering on Linux

### DIFF
--- a/src/fontview/main.cpp
+++ b/src/fontview/main.cpp
@@ -353,7 +353,7 @@ void MyFrame::OnChangeSampleText(wxCommandEvent& event) {
   // This is needed on GTK+, where wxWidgets doesn't use UTF8 internally.
   std::string text(dialog.GetValue().mb_str(wxConvUTF8));
   sampleText_->SetText(text, true);
-  sampleText_->Paint();
+  sampleText_->Refresh();
 }
 
 void MyFrame::OnAbout(wxCommandEvent& event) {
@@ -407,7 +407,7 @@ void MyFrame::OnTextSettingsChanged() {
     if (!sampleText_->HasCustomText() && curStyle) {
       sampleText_->SetText(curStyle->GetSampleText(), false);
     }
-    sampleText_->Paint();
+    sampleText_->Refresh();
   }
 
   processingModelChange_ = false;

--- a/src/fontview/sample_text.cpp
+++ b/src/fontview/sample_text.cpp
@@ -67,16 +67,6 @@ wxSize SampleText::DoGetBestSize() const {
   return wxSize(600, 300);
 }
 
-void SampleText::Paint() {
-  wxWindowDC dc(this);
-  Paint(dc);
-}
-
-void SampleText::OnPaint(wxPaintEvent& event) {
-  wxPaintDC dc(this);
-  Paint(dc);
-}
-
 static void CopyAlpha(const FT_Bitmap& source,
                       int leftOffset, int topOffset,
                       wxBitmap* target) {
@@ -166,7 +156,8 @@ void SampleText::DrawGlyph(wxDC& dc, FT_Face face, FT_UInt glyph,
   FT_Bitmap_Done(face->glyph->library, &ftBitmap);
 }
 
-void SampleText::Paint(wxDC& dc) {
+void SampleText::OnPaint(wxPaintEvent& event) {
+  wxPaintDC dc(this);
   if (!fontFace_ || !dc.IsOk()) {
     return;
   }

--- a/src/fontview/sample_text.h
+++ b/src/fontview/sample_text.h
@@ -43,7 +43,6 @@ class SampleText : public wxScrolledCanvas {
   void SetTextLanguage(const std::string& language);  // BCP47 code
   void SetFontFace(FT_Face fontFace);
   void SetFontSize(double size);
-  void Paint();
   wxDECLARE_EVENT_TABLE();
 
  protected:
@@ -51,7 +50,6 @@ class SampleText : public wxScrolledCanvas {
 
  private:
   void OnPaint(wxPaintEvent& event);
-  void Paint(wxDC& dc);
   void DrawGlyph(wxDC& dc, FT_Face face, FT_UInt glyph, double x, double y);
 
   bool hasCustomText_;


### PR DESCRIPTION
Apparently just call Refresh() when wanting to repaint the widget instead of manually re-painting fixes the flickering on Linux.