### PR TITLE
Add a simple Makefile for building on Linux with system libraries

### DIFF
--- a/src/fontview/Makefile
+++ b/src/fontview/Makefile
@@ -1,0 +1,5 @@
+fontview: *.cpp
+	g++ -std=c++11 *.cpp `pkg-config --cflags --libs fribidi harfbuzz freetype2 raqm` `wx-config --cflags --libs` -I .. -o fontview
+
+clean:
+	rm -f fontview


### PR DESCRIPTION
Using build.py on Linux I still get:
```
behdad:fontview 130 (master)$ python build.py 
Traceback (most recent call last):
  File "build.py", line 134, in <module>
    main()
  File "build.py", line 29, in main
    success = build_linux(release)
  File "build.py", line 92, in build_linux
    '-o', 'build/fontview'] + fontview_sources)
  File "/usr/lib/python2.7/subprocess.py", line 181, in check_call
    retcode = call(*popenargs, **kwargs)
  File "/usr/lib/python2.7/subprocess.py", line 168, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/lib/python2.7/subprocess.py", line 390, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1024, in _execute_child
    raise child_exception
OSError: [Errno 36] File name too long
```

This two-line Makefile does the job well for me, and I suppose others.