### PR TITLE
Add English names for Syriac variants

### DIFF
--- a/src/fontview/main.cpp
+++ b/src/fontview/main.cpp
@@ -508,6 +508,9 @@ void MyFrame::RebuildAxisSliders() {
 static const std::map<std::string, std::string> languageNames = {
   {"und-fonipa", "International Phonetic Alphabet"},
   {"und-fonnapa", "North American Phonetic Alphabet"},
+  {"und-syre", "Estrangelo Syriac"},
+  {"und-syrj", "Western Syriac"},
+  {"und-syrn", "Eastern Syriac"},
 
   // TODO: Remove this once HarfBuzz returns proper BCP47 codes.
   {"mo", "Moldavian"},  // deprecated; should be ro-MD


### PR DESCRIPTION
An upcoming version of the Noto Sans Syriac font will support
the OpenType language system tags for Syriac which were introduced
with OpenType 1.8.1 in January 2017. The corresponding HarfBuzz
change was done soon thereafter, but so far, FontView did not
display an English name in its language picker menu.