### PR TITLE
store sample string and fontSize in wxSystemOptions

### DIFF
--- a/src/fontview/main.cpp
+++ b/src/fontview/main.cpp
@@ -31,6 +31,7 @@
 #include <wx/slider.h>
 #include <wx/spinctrl.h>
 #include <wx/textctrl.h>
+#include <wx/sysopt.h>
 
 #include <ft2build.h>
 #include FT_FREETYPE_H
@@ -156,8 +157,12 @@ void MyApp::MacNewFile() {
 }
 
 void MyApp::MacOpenFile(const wxString& path) {
+  std::string sample = wxSystemOptions::GetOption("SampleText").ToStdString();
+  if (sample == "") {
+    sample = defaultSampleText_;
+  }
   std::unique_ptr<TextSettings> textSettings(
-      new TextSettings(defaultSampleText_));
+      new TextSettings(sample));
   if (!textSettings->SetFontContainer(path.ToStdString())) {
     wxMessageBox("FontView does not understand "
                  "the format of the selected file.",
@@ -1196,11 +1201,14 @@ void MyFrame::OnAxisSliderChanged(wxCommandEvent& event) {
 }
 
 void MyFrame::OnFontSizeFieldChanged(wxSpinDoubleEvent& event) {
-  textSettings_->SetFontSize(event.GetValue());
+  int fontSize = event.GetValue();
+  wxSystemOptions::SetOption("FontSize", fontSize);
+  textSettings_->SetFontSize(fontSize);
 }
 
 void MyFrame::OnSampleTextFieldChanged(wxCommandEvent& event) {
   const std::string text = event.GetString().ToStdString();
+  wxSystemOptions::SetOption("SampleText", text);
   sampleText_->SetText(text, true);
   sampleText_->Refresh();
 }

--- a/src/fontview/text_settings.cpp
+++ b/src/fontview/text_settings.cpp
@@ -21,6 +21,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <iostream>
 
 #include <ft2build.h>
 #include FT_FREETYPE_H
@@ -34,6 +35,7 @@
 #include "util.h"
 
 #include <wx/filename.h>
+#include <wx/sysopt.h>
 
 namespace fontview {
 
@@ -248,7 +250,9 @@ bool TextSettings::SetStyleWithoutNotification(FontStyle* style) {
 void TextSettings::Clear() {
   textLanguage_ = "und";
   supportedTextLanguages_.clear();
-  fontSize_ = defaultFontSize;
+  fontSize_ = wxSystemOptions::GetOptionInt("FontSize");
+  if (fontSize_ == 0)
+    fontSize_ = defaultFontSize;
   variation_.clear();
   style_ = NULL;
   family_.clear();


### PR DESCRIPTION
This is not surviving an app restart but it is better than nothing as all fonts that are opened later keep the settings.