### PR TITLE
Round glyph positions when drawing sample text to bitmap instead of truncating. [#50]

### DIFF
--- a/src/fontview/sample_text.cpp
+++ b/src/fontview/sample_text.cpp
@@ -150,7 +150,7 @@ void SampleText::DrawGlyph(wxDC& dc, FT_Face face, FT_UInt glyph,
 			  ceil(height / scale) + topOffset,
 			  32, scale)) {
     CopyAlpha(ftBitmap, leftOffset, topOffset, &bitmap);
-    dc.DrawBitmap(bitmap, xPos, yPos);
+    dc.DrawBitmap(bitmap, round(xPos), round(yPos));
   }
 
   FT_Bitmap_Done(face->glyph->library, &ftBitmap);


### PR DESCRIPTION
This fixes the inter-glyph spacing at smaller font sizes

with font 
https://github.com/adobe-fonts/source-sans-pro/blob/release/OTF/SourceSansPro-Regular.otf
Before
![chromevsfontview](https://user-images.githubusercontent.com/77501/50319066-4bcde880-0493-11e9-956f-745cd020058e.png)

After
![screen shot 2018-12-20 at 8 07 20 pm](https://user-images.githubusercontent.com/77501/50319084-630cd600-0493-11e9-9fb7-a9f90af0a2af.png)
