### PR TITLE
Python 3 build updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ git clone --recursive https://github.com/googlei18n/fontview.git;
 # if you forget the recursive arg, run
 # git submodule update --init --recursive
 $ cd fontview
-$ python2.7 build.py && ./build/FontView.app/Contents/MacOS/fontview
+$ python3 build.py && ./build/FontView.app/Contents/MacOS/fontview
 ```
 
 ## Building on Linux

--- a/build.py
+++ b/build.py
@@ -14,7 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse, codecs, shutil, subprocess, os, sys
+import argparse
+import codecs
+import shutil
+import os
+import subprocess
+import sys
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -44,6 +50,7 @@ def build_mac(release):
         return False
     return True
 
+
 def check_pkgconfig(lib, min_version):
     try:
         subprocess.check_output(
@@ -53,6 +60,7 @@ def check_pkgconfig(lib, min_version):
         return False
 
     return True
+
 
 def build_linux(release):
     if os.path.exists('build'):

--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python3
 #
 # Copyright 2017 Google Inc. All rights reserved.
 #
@@ -49,7 +49,7 @@ def check_pkgconfig(lib, min_version):
         subprocess.check_output(
             ['pkg-config', '--atleast-version', min_version, lib])
     except subprocess.CalledProcessError:
-        print("%s >= %s is missing" % (lib, min_version))
+        print(("%s >= %s is missing" % (lib, min_version)))
         return False
 
     return True


### PR DESCRIPTION
This PR updates the build.py file with changes rec'd by `2to3` and changes the shebang to `#!/usr/bin/env python3`.  I also included a handful of flake8 linter updates on the build script and updated the build instructions on the README.

When the issue in https://github.com/googlefonts/fontview/issues/57 is addressed locally, this builds without issues for me on macOS 10.14.4.